### PR TITLE
add disconnect node shutdown

### DIFF
--- a/src/mqtt_bridge/app.py
+++ b/src/mqtt_bridge/app.py
@@ -72,6 +72,7 @@ def _on_connect(client, userdata, flags, response_code):
 
 def _on_disconnect(client, userdata, response_code):
     rospy.loginfo('MQTT disconnected')
+    rospy.signal_shutdown('MQTT disconnected')
 
 
 __all__ = ['mqtt_bridge_node']


### PR DESCRIPTION
## なんのための変更？

* ゆきひめで電波の弱いところに行くとGUI操作が効かなくなる(ROSへ通知が行ってない)

## やったこと

* mosquittoがrestartや再接続が起きた時に、MQTT bridgeもノード落とすようにした
* launch側でノードのrespawnする

## やらないこと

* なし

## 影響範囲

* ROS - GUI連携部分

## 動作確認

* simでmosquittoをstop/startを繰り返してGUI操作できることを確認

## 悩んでいるところ、とくにレビューしてほしいところ

* なし
