### PR TITLE
Feature/fix reconnection behavior

### DIFF
--- a/src/mqtt_bridge/app.py
+++ b/src/mqtt_bridge/app.py
@@ -58,7 +58,7 @@ def mqtt_bridge_node():
     # configure and connect to MQTT broker
     mqtt_client.on_connect = _on_connect
     mqtt_client.on_disconnect = _on_disconnect
-    mqtt_client.connect(**conn_params)
+    mqtt_client.connect_async(**conn_params)
 
     # start MQTT loop
     mqtt_client.loop_start()

--- a/src/mqtt_bridge/app.py
+++ b/src/mqtt_bridge/app.py
@@ -1,10 +1,14 @@
+from typing import List
+
 import inject
 import paho.mqtt.client as mqtt
 import rospy
 
-from .bridge import create_bridge
+from .bridge import Bridge, create_bridge
 from .mqtt_client import create_private_path_extractor
 from .util import lookup_object
+
+_bridges: List[Bridge] = []
 
 
 def create_config(mqtt_client, serializer, deserializer, mqtt_private_path):
@@ -47,15 +51,14 @@ def mqtt_bridge_node():
         mqtt_client, serializer, deserializer, mqtt_private_path)
     inject.configure(config)
 
+    # configure bridges
+    global _bridges
+    _bridges = [create_bridge(**bridge_args) for bridge_args in bridge_params]
+
     # configure and connect to MQTT broker
     mqtt_client.on_connect = _on_connect
     mqtt_client.on_disconnect = _on_disconnect
     mqtt_client.connect(**conn_params)
-
-    # configure bridges
-    bridges = []
-    for bridge_args in bridge_params:
-        bridges.append(create_bridge(**bridge_args))
 
     # start MQTT loop
     mqtt_client.loop_start()
@@ -68,10 +71,14 @@ def mqtt_bridge_node():
 
 def _on_connect(client, userdata, flags, response_code):
     rospy.loginfo('MQTT connected')
+    for bridge in _bridges:
+        bridge.on_mqtt_connect()
 
 
 def _on_disconnect(client, userdata, response_code):
     rospy.loginfo('MQTT disconnected')
+    for bridge in _bridges:
+        bridge.on_mqtt_disconnect()
 
 
 __all__ = ['mqtt_bridge_node']

--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta
-from typing import Optional, Type, Dict, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import inject
 import paho.mqtt.client as mqtt
@@ -8,10 +8,16 @@ import rospy
 from .util import lookup_object, extract_values, populate_instance
 
 
-def create_bridge(factory: Union[str, "Bridge"], msg_type: Union[str, Type[rospy.Message]], topic_from: str,
-                  topic_to: str, frequency: Optional[float] = None, **kwargs) -> "Bridge":
-    """ generate bridge instance using factory callable and arguments. if `factory` or `meg_type` is provided as string,
-     this function will convert it to a corresponding object.
+def create_bridge(
+    factory: Union[str, "Bridge"],
+    msg_type: Union[str, Type[rospy.Message]],
+    topic_from: str,
+    topic_to: str,
+    frequency: Optional[float] = None,
+    **kwargs,
+) -> "Bridge":
+    """generate bridge instance using factory callable and arguments. if `factory` or `meg_type` is provided as string,
+    this function will convert it to a corresponding object.
     """
     if isinstance(factory, str):
         factory = lookup_object(factory)
@@ -20,28 +26,65 @@ def create_bridge(factory: Union[str, "Bridge"], msg_type: Union[str, Type[rospy
     if isinstance(msg_type, str):
         msg_type = lookup_object(msg_type)
     if not issubclass(msg_type, rospy.Message):
-        raise TypeError(
-            "msg_type should be rospy.Message instance or its string"
-            "reprensentation")
-    return factory(
-        topic_from=topic_from, topic_to=topic_to, msg_type=msg_type, frequency=frequency, **kwargs)
+        raise TypeError("msg_type should be rospy.Message instance or its stringreprensentation")
+    return factory(topic_from=topic_from, topic_to=topic_to, msg_type=msg_type, frequency=frequency, **kwargs)
 
 
 class Bridge(object, metaclass=ABCMeta):
-    """ Bridge base class """
-    _mqtt_client = inject.attr(mqtt.Client)
-    _serialize = inject.attr('serializer')
-    _deserialize = inject.attr('deserializer')
-    _extract_private_path = inject.attr('mqtt_private_path_extractor')
+    """Bridge base class"""
+
+    __mqtt_client = inject.attr(mqtt.Client)
+    _serialize = inject.attr("serializer")
+    _deserialize = inject.attr("deserializer")
+    _extract_private_path = inject.attr("mqtt_private_path_extractor")
+
+    def __init__(self):
+        self.__subs: List[Tuple[str, int]] = []
+        self.__pubs: Dict[str, Tuple[Any, int]] = {}
+
+    def _mqtt_subscribe(self, topic: str, callback: Callable[[mqtt.MQTTMessage], None], qos=0):
+        self.__subs.append((topic, qos))
+        Bridge.__mqtt_client.message_callback_add(topic, lambda c, u, msg: callback(msg))
+
+    def _mqtt_publish(self, topic: str, payload: Any, qos=0, retain=False):
+        if retain:
+            if payload:  # This expression ignores int or float cases because they will not be used in our application.
+                self.__pubs[topic] = (payload, qos)
+            else:
+                # Delete retained message.
+                del self.__pubs[topic]
+        self.__mqtt_client.publish(topic, payload, qos, retain)
+
+    def on_mqtt_connect(self):
+        for topic, qos in self.__subs:
+            rospy.logdebug(f"Subscribe topic=\"{topic}\", qos={qos}")
+            Bridge.__mqtt_client.subscribe(topic, qos)
+        for topic, (payload, qos) in self.__pubs.items():
+            rospy.logdebug(f"Publish retained topic=\"{topic}\", qos={qos}")
+            self.__mqtt_client.publish(topic, payload, qos, True)
+
+    def on_mqtt_disconnect(self):
+        pass
+
+    @staticmethod
+    def _create_ros_message(mqtt_msg: mqtt.MQTTMessage, msg_type: Type[rospy.Message]) -> rospy.Message:
+        """create ROS message from MQTT payload"""
+        # Hack to enable both, messagepack and json deserialization.
+        if Bridge._serialize.__name__ == "packb":
+            msg_dict = Bridge._deserialize(mqtt_msg.payload, raw=False)
+        else:
+            msg_dict = Bridge._deserialize(mqtt_msg.payload)
+        return populate_instance(msg_dict, msg_type())
 
 
 class RosToMqttBridge(Bridge):
-    """ Bridge from ROS topic to MQTT
+    """Bridge from ROS topic to MQTT
 
     bridge ROS messages on `topic_from` to MQTT topic `topic_to`. expect `msg_type` ROS message type.
     """
 
     def __init__(self, topic_from: str, topic_to: str, msg_type: rospy.Message, frequency: Optional[float] = None):
+        super().__init__()
         self._topic_from = topic_from
         self._topic_to = self._extract_private_path(topic_to)
         self._last_published = rospy.get_time()
@@ -49,7 +92,6 @@ class RosToMqttBridge(Bridge):
         rospy.Subscriber(topic_from, msg_type, self._callback_ros)
 
     def _callback_ros(self, msg: rospy.Message):
-        rospy.logdebug("ROS received from {}".format(self._topic_from))
         now = rospy.get_time()
         if now - self._last_published >= self._interval:
             self._publish(msg)
@@ -57,50 +99,37 @@ class RosToMqttBridge(Bridge):
 
     def _publish(self, msg: rospy.Message):
         payload = self._serialize(extract_values(msg))
-        self._mqtt_client.publish(topic=self._topic_to, payload=payload)
+        self._mqtt_publish(self._topic_to, payload)
 
 
 class MqttToRosBridge(Bridge):
-    """ Bridge from MQTT to ROS topic
+    """Bridge from MQTT to ROS topic
 
     bridge MQTT messages on `topic_from` to ROS topic `topic_to`. MQTT messages will be converted to `msg_type`.
     """
 
-    def __init__(self, topic_from: str, topic_to: str, msg_type: Type[rospy.Message],
-                 frequency: Optional[float] = None, queue_size: int = 10):
+    def __init__(self, topic_from: str, topic_to: str, msg_type: Type[rospy.Message], frequency: Optional[float] = None, queue_size: int = 10):
+        super().__init__()
         self._topic_from = self._extract_private_path(topic_from)
         self._topic_to = topic_to
         self._msg_type = msg_type
         self._queue_size = queue_size
         self._last_published = rospy.get_time()
         self._interval = None if frequency is None else 1.0 / frequency
-        # Adding the correct topic to subscribe to
-        self._mqtt_client.subscribe(self._topic_from)
-        self._mqtt_client.message_callback_add(self._topic_from, self._callback_mqtt)
-        self._publisher = rospy.Publisher(
-            self._topic_to, self._msg_type, queue_size=self._queue_size)
+        self._mqtt_subscribe(self._topic_from, self._callback_mqtt)
+        self._publisher = rospy.Publisher(self._topic_to, self._msg_type, queue_size=self._queue_size)
 
-    def _callback_mqtt(self, client: mqtt.Client, userdata: Dict, mqtt_msg: mqtt.MQTTMessage):
-        """ callback from MQTT """
-        rospy.logdebug("MQTT received from {}".format(mqtt_msg.topic))
+    def _callback_mqtt(self, mqtt_msg: mqtt.MQTTMessage):
+        """callback from MQTT"""
         now = rospy.get_time()
 
         if self._interval is None or now - self._last_published >= self._interval:
             try:
-                ros_msg = self._create_ros_message(mqtt_msg)
+                ros_msg = Bridge._create_ros_message(mqtt_msg, self._msg_type)
                 self._publisher.publish(ros_msg)
                 self._last_published = now
             except Exception as e:
                 rospy.logerr(e)
 
-    def _create_ros_message(self, mqtt_msg: mqtt.MQTTMessage) -> rospy.Message:
-        """ create ROS message from MQTT payload """
-        # Hack to enable both, messagepack and json deserialization.
-        if self._serialize.__name__ == "packb":
-            msg_dict = self._deserialize(mqtt_msg.payload, raw=False)
-        else:
-            msg_dict = self._deserialize(mqtt_msg.payload)
-        return populate_instance(msg_dict, self._msg_type())
 
-
-__all__ = ['create_bridge', 'Bridge', 'RosToMqttBridge', 'MqttToRosBridge']
+__all__ = ["create_bridge", "Bridge", "RosToMqttBridge", "MqttToRosBridge"]


### PR DESCRIPTION
## なんのための変更？

* MQTTブローカーと再接続したとき、あるいはMQTTブローカーが再起動したときの処理を改善する。

## やったこと

MQTTトピックのサブスクライブとパブリッシュする処理をラッピングしたメソッドをベースクラス`Bridge`に用意した。  
継承クラスはこれらを用いてMQTTでサブスクライブ、パブリッシュする。
- `Bridge._mqtt_subscribe()`  
- `Bridge._mqtt_publish()`  

MQTTブローカーとの再接続が行われたとき以下の処理が自動的に行われるようになる。
* トピックをサブスクライブしなおす。
* `retain=1`でパブリッシュされたメッセージを再びパブリッシュする。

## やらないこと

* なし

## 影響範囲

* この変更に合わせて継承クラスの修正が必要。

## 動作確認

* シミュレータでmosquittoを再起動して、次のケースでGUIの状態とROSの接続が保たれることを確認した。
  * GUIを開いている最中にmosquittoを再起動する
  * GUIを開く前にmosquittoを再起動する

## 悩んでいるところ、とくにレビューしてほしいところ

* なし